### PR TITLE
[ENG-2462] handle local libs

### DIFF
--- a/composer_local_dev/cli.py
+++ b/composer_local_dev/cli.py
@@ -47,7 +47,7 @@ click.rich_click.OPTION_GROUPS = {
         },
         {
             "name": "Environment options",
-            "options": ["--web-server-port", "--dags-path"],
+            "options": ["--web-server-port", "--dags-path", "--dags-subpath-exclude"],
         },
     ],
     "composer-dev start": [COMMON_OPTIONS],
@@ -225,6 +225,13 @@ option_location = click.option(
     metavar="PATH",
     type=click.Path(file_okay=False),
 )
+@click.option(
+    "--dags-subpath-exclude",
+    help="A file or folder that should be excluded from mounting to the dags directory.",
+    show_default="none",
+    metavar="PATH",
+    type=click.Path(file_okay=False),
+)
 @required_environment
 @verbose_mode
 @debug_mode
@@ -239,6 +246,7 @@ def create(
     verbose: bool,
     debug: bool,
     dags_path: Optional[pathlib.Path] = None,
+    dags_subpath_exclude: Optional[str] = None,
 ):
     """
     Create local Composer development environment.
@@ -292,6 +300,7 @@ def create(
             env_dir_path=env_dir,
             web_server_port=web_server_port,
             dags_path=dags_path,
+            dags_subpath_exclude=dags_subpath_exclude,
         )
     else:
         env = composer_environment.Environment(
@@ -301,6 +310,7 @@ def create(
             env_dir_path=env_dir,
             port=web_server_port,
             dags_path=dags_path,
+            dags_subpath_exclude=dags_subpath_exclude,
         )
     env.create()
 

--- a/composer_local_dev/constants.py
+++ b/composer_local_dev/constants.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 import enum
 
+# TZ exclusions list for mounting DAGs
+DAGS_DIR_EXCLUDE_FROM_MOUNT = [ "tz" ]
+
 # The name of environment variable with custom configuration path
 CLOUD_CLI_CONFIG_PATH_ENV = "CLOUDSDK_CONFIG"
 

--- a/composer_local_dev/constants.py
+++ b/composer_local_dev/constants.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 import enum
 
-# TZ exclusions list for mounting DAGs
-DAGS_DIR_EXCLUDE_FROM_MOUNT = [ "tz" ]
-
 # The name of environment variable with custom configuration path
 CLOUD_CLI_CONFIG_PATH_ENV = "CLOUDSDK_CONFIG"
 

--- a/composer_local_dev/environment.py
+++ b/composer_local_dev/environment.py
@@ -59,13 +59,12 @@ def get_image_mounts(
     """
     mount_paths = {
         requirements: "composer_requirements.txt",
-        dags_path: "gcs/dags/",
         env_path / "plugins": "gcs/plugins/",
         env_path / "data": "gcs/data/",
         gcloud_config_path: ".config/gcloud",
         env_path / "airflow.db": "airflow/airflow.db",
     }
-    return [
+    mounts = [
         docker.types.Mount(
             source=str(source),
             target=f"{constants.AIRFLOW_HOME}/{target}",
@@ -73,6 +72,17 @@ def get_image_mounts(
         )
         for source, target in mount_paths.items()
     ]
+
+    dags_mount_path = f"{constants.AIRFLOW_HOME}/gcs/dags/"
+
+    for item in pathlib.Path(dags_path).iterdir():
+        if item.name not in constants.DAGS_DIR_EXCLUDE_FROM_MOUNT:
+            mounts.append(docker.types.Mount(
+                source=str(item.resolve()),
+                target=f"{dags_mount_path}/{item.name}",
+                type="bind",
+            ))
+    return mounts
 
 
 def get_default_environment_variables(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ dependencies = [
     "google-cloud-orchestration-airflow>=1.2.0",
     "google-cloud-artifact-registry>=1.2.0",
     "rich_click==1.4.0",
-    "docker==6.*",
+    "docker==7.*",
 ]
 extras = {
     "tests": ["pytest", "nox", "coverage"],


### PR DESCRIPTION
Added a command-line argument `--dags-subpath-exclude` so that we can exclude `dags/tz` from being mounted. This allows us to copy from `dags/tz` instead so that we can resolve symlinks.

Also upgrades `docker` client due to conflict with `requests==2.32.0` (see [Github Issue 3256](https://github.com/docker/docker-py/issues/3256)).